### PR TITLE
feat(catalog): Build initial CatalogService using Clean Architecture and DDD

### DIFF
--- a/Auctify.sln
+++ b/Auctify.sln
@@ -19,6 +19,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Libraries", "Libraries", "{
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Auctify.Libraries.Domain.Abstractions", "src\Libraries\Auctify.Libraries.Domain.Abstractions\Auctify.Libraries.Domain.Abstractions.csproj", "{AB07D138-F182-4F86-83F3-CEEF8630D12F}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "CatalogService", "CatalogService", "{09734656-93E7-93B1-A2F5-3066A08F773B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Auctify.CatalogService.Domain", "src\Services\CatalogService\Auctify.CatalogService.Domain\Auctify.CatalogService.Domain.csproj", "{829C62CF-A611-4832-A8C5-4DD6BCBB1424}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -65,6 +69,18 @@ Global
 		{AB07D138-F182-4F86-83F3-CEEF8630D12F}.Release|x64.Build.0 = Release|Any CPU
 		{AB07D138-F182-4F86-83F3-CEEF8630D12F}.Release|x86.ActiveCfg = Release|Any CPU
 		{AB07D138-F182-4F86-83F3-CEEF8630D12F}.Release|x86.Build.0 = Release|Any CPU
+		{829C62CF-A611-4832-A8C5-4DD6BCBB1424}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{829C62CF-A611-4832-A8C5-4DD6BCBB1424}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{829C62CF-A611-4832-A8C5-4DD6BCBB1424}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{829C62CF-A611-4832-A8C5-4DD6BCBB1424}.Debug|x64.Build.0 = Debug|Any CPU
+		{829C62CF-A611-4832-A8C5-4DD6BCBB1424}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{829C62CF-A611-4832-A8C5-4DD6BCBB1424}.Debug|x86.Build.0 = Debug|Any CPU
+		{829C62CF-A611-4832-A8C5-4DD6BCBB1424}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{829C62CF-A611-4832-A8C5-4DD6BCBB1424}.Release|Any CPU.Build.0 = Release|Any CPU
+		{829C62CF-A611-4832-A8C5-4DD6BCBB1424}.Release|x64.ActiveCfg = Release|Any CPU
+		{829C62CF-A611-4832-A8C5-4DD6BCBB1424}.Release|x64.Build.0 = Release|Any CPU
+		{829C62CF-A611-4832-A8C5-4DD6BCBB1424}.Release|x86.ActiveCfg = Release|Any CPU
+		{829C62CF-A611-4832-A8C5-4DD6BCBB1424}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -77,5 +93,7 @@ Global
 		{782E17FE-A561-48C0-A813-EC01FD77D066} = {2313983C-1317-952D-92FE-B695B265D59A}
 		{5E7EC0AF-E837-5B7A-FB41-A4DCCA877D1F} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{AB07D138-F182-4F86-83F3-CEEF8630D12F} = {5E7EC0AF-E837-5B7A-FB41-A4DCCA877D1F}
+		{09734656-93E7-93B1-A2F5-3066A08F773B} = {984BB9B3-3FA3-BE33-9484-CAC21695A33C}
+		{829C62CF-A611-4832-A8C5-4DD6BCBB1424} = {09734656-93E7-93B1-A2F5-3066A08F773B}
 	EndGlobalSection
 EndGlobal

--- a/Auctify.sln
+++ b/Auctify.sln
@@ -27,6 +27,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Auctify.CatalogService.Appl
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Auctify.CatalogService.Infrastructure", "src\Services\CatalogService\Auctify.CatalogService.Infrastructure\Auctify.CatalogService.Infrastructure.csproj", "{9B409B65-CA6D-45E9-9FFC-6F540B1562B2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Auctify.CatalogService.WebAPI", "src\Services\CatalogService\Auctify.CatalogService.WebAPI\Auctify.CatalogService.WebAPI.csproj", "{DAF4F5B6-5686-453D-9A8D-DABD48AF4FFE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -109,6 +111,18 @@ Global
 		{9B409B65-CA6D-45E9-9FFC-6F540B1562B2}.Release|x64.Build.0 = Release|Any CPU
 		{9B409B65-CA6D-45E9-9FFC-6F540B1562B2}.Release|x86.ActiveCfg = Release|Any CPU
 		{9B409B65-CA6D-45E9-9FFC-6F540B1562B2}.Release|x86.Build.0 = Release|Any CPU
+		{DAF4F5B6-5686-453D-9A8D-DABD48AF4FFE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DAF4F5B6-5686-453D-9A8D-DABD48AF4FFE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DAF4F5B6-5686-453D-9A8D-DABD48AF4FFE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DAF4F5B6-5686-453D-9A8D-DABD48AF4FFE}.Debug|x64.Build.0 = Debug|Any CPU
+		{DAF4F5B6-5686-453D-9A8D-DABD48AF4FFE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DAF4F5B6-5686-453D-9A8D-DABD48AF4FFE}.Debug|x86.Build.0 = Debug|Any CPU
+		{DAF4F5B6-5686-453D-9A8D-DABD48AF4FFE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DAF4F5B6-5686-453D-9A8D-DABD48AF4FFE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DAF4F5B6-5686-453D-9A8D-DABD48AF4FFE}.Release|x64.ActiveCfg = Release|Any CPU
+		{DAF4F5B6-5686-453D-9A8D-DABD48AF4FFE}.Release|x64.Build.0 = Release|Any CPU
+		{DAF4F5B6-5686-453D-9A8D-DABD48AF4FFE}.Release|x86.ActiveCfg = Release|Any CPU
+		{DAF4F5B6-5686-453D-9A8D-DABD48AF4FFE}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -125,5 +139,9 @@ Global
 		{829C62CF-A611-4832-A8C5-4DD6BCBB1424} = {09734656-93E7-93B1-A2F5-3066A08F773B}
 		{C272D6B7-34F6-4FC3-9E2D-210633FE1707} = {09734656-93E7-93B1-A2F5-3066A08F773B}
 		{9B409B65-CA6D-45E9-9FFC-6F540B1562B2} = {09734656-93E7-93B1-A2F5-3066A08F773B}
+		{DAF4F5B6-5686-453D-9A8D-DABD48AF4FFE} = {09734656-93E7-93B1-A2F5-3066A08F773B}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {7B78C610-CFBA-4D61-A80C-D796B32E65C4}
 	EndGlobalSection
 EndGlobal

--- a/Auctify.sln
+++ b/Auctify.sln
@@ -25,6 +25,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Auctify.CatalogService.Doma
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Auctify.CatalogService.Application", "src\Services\CatalogService\Auctify.CatalogService.Application\Auctify.CatalogService.Application.csproj", "{C272D6B7-34F6-4FC3-9E2D-210633FE1707}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Auctify.CatalogService.Infrastructure", "src\Services\CatalogService\Auctify.CatalogService.Infrastructure\Auctify.CatalogService.Infrastructure.csproj", "{9B409B65-CA6D-45E9-9FFC-6F540B1562B2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -95,6 +97,18 @@ Global
 		{C272D6B7-34F6-4FC3-9E2D-210633FE1707}.Release|x64.Build.0 = Release|Any CPU
 		{C272D6B7-34F6-4FC3-9E2D-210633FE1707}.Release|x86.ActiveCfg = Release|Any CPU
 		{C272D6B7-34F6-4FC3-9E2D-210633FE1707}.Release|x86.Build.0 = Release|Any CPU
+		{9B409B65-CA6D-45E9-9FFC-6F540B1562B2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9B409B65-CA6D-45E9-9FFC-6F540B1562B2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9B409B65-CA6D-45E9-9FFC-6F540B1562B2}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9B409B65-CA6D-45E9-9FFC-6F540B1562B2}.Debug|x64.Build.0 = Debug|Any CPU
+		{9B409B65-CA6D-45E9-9FFC-6F540B1562B2}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9B409B65-CA6D-45E9-9FFC-6F540B1562B2}.Debug|x86.Build.0 = Debug|Any CPU
+		{9B409B65-CA6D-45E9-9FFC-6F540B1562B2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9B409B65-CA6D-45E9-9FFC-6F540B1562B2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9B409B65-CA6D-45E9-9FFC-6F540B1562B2}.Release|x64.ActiveCfg = Release|Any CPU
+		{9B409B65-CA6D-45E9-9FFC-6F540B1562B2}.Release|x64.Build.0 = Release|Any CPU
+		{9B409B65-CA6D-45E9-9FFC-6F540B1562B2}.Release|x86.ActiveCfg = Release|Any CPU
+		{9B409B65-CA6D-45E9-9FFC-6F540B1562B2}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -110,5 +124,6 @@ Global
 		{09734656-93E7-93B1-A2F5-3066A08F773B} = {984BB9B3-3FA3-BE33-9484-CAC21695A33C}
 		{829C62CF-A611-4832-A8C5-4DD6BCBB1424} = {09734656-93E7-93B1-A2F5-3066A08F773B}
 		{C272D6B7-34F6-4FC3-9E2D-210633FE1707} = {09734656-93E7-93B1-A2F5-3066A08F773B}
+		{9B409B65-CA6D-45E9-9FFC-6F540B1562B2} = {09734656-93E7-93B1-A2F5-3066A08F773B}
 	EndGlobalSection
 EndGlobal

--- a/Auctify.sln
+++ b/Auctify.sln
@@ -23,6 +23,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "CatalogService", "CatalogSe
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Auctify.CatalogService.Domain", "src\Services\CatalogService\Auctify.CatalogService.Domain\Auctify.CatalogService.Domain.csproj", "{829C62CF-A611-4832-A8C5-4DD6BCBB1424}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Auctify.CatalogService.Application", "src\Services\CatalogService\Auctify.CatalogService.Application\Auctify.CatalogService.Application.csproj", "{C272D6B7-34F6-4FC3-9E2D-210633FE1707}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -81,6 +83,18 @@ Global
 		{829C62CF-A611-4832-A8C5-4DD6BCBB1424}.Release|x64.Build.0 = Release|Any CPU
 		{829C62CF-A611-4832-A8C5-4DD6BCBB1424}.Release|x86.ActiveCfg = Release|Any CPU
 		{829C62CF-A611-4832-A8C5-4DD6BCBB1424}.Release|x86.Build.0 = Release|Any CPU
+		{C272D6B7-34F6-4FC3-9E2D-210633FE1707}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C272D6B7-34F6-4FC3-9E2D-210633FE1707}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C272D6B7-34F6-4FC3-9E2D-210633FE1707}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C272D6B7-34F6-4FC3-9E2D-210633FE1707}.Debug|x64.Build.0 = Debug|Any CPU
+		{C272D6B7-34F6-4FC3-9E2D-210633FE1707}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C272D6B7-34F6-4FC3-9E2D-210633FE1707}.Debug|x86.Build.0 = Debug|Any CPU
+		{C272D6B7-34F6-4FC3-9E2D-210633FE1707}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C272D6B7-34F6-4FC3-9E2D-210633FE1707}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C272D6B7-34F6-4FC3-9E2D-210633FE1707}.Release|x64.ActiveCfg = Release|Any CPU
+		{C272D6B7-34F6-4FC3-9E2D-210633FE1707}.Release|x64.Build.0 = Release|Any CPU
+		{C272D6B7-34F6-4FC3-9E2D-210633FE1707}.Release|x86.ActiveCfg = Release|Any CPU
+		{C272D6B7-34F6-4FC3-9E2D-210633FE1707}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -95,5 +109,6 @@ Global
 		{AB07D138-F182-4F86-83F3-CEEF8630D12F} = {5E7EC0AF-E837-5B7A-FB41-A4DCCA877D1F}
 		{09734656-93E7-93B1-A2F5-3066A08F773B} = {984BB9B3-3FA3-BE33-9484-CAC21695A33C}
 		{829C62CF-A611-4832-A8C5-4DD6BCBB1424} = {09734656-93E7-93B1-A2F5-3066A08F773B}
+		{C272D6B7-34F6-4FC3-9E2D-210633FE1707} = {09734656-93E7-93B1-A2F5-3066A08F773B}
 	EndGlobalSection
 EndGlobal

--- a/src/Libraries/Auctify.Libraries.Domain.Abstractions/Aggregate.cs
+++ b/src/Libraries/Auctify.Libraries.Domain.Abstractions/Aggregate.cs
@@ -6,7 +6,7 @@ using Wiaoj.Extensions;
 
 namespace Auctify.Libraries.Domain.Abstractions;
 public abstract class Aggregate<TId> : Entity<TId>, IAggregate, IHasDomainEvent
-    where TId : class, IId<TId> {
+    where TId : class, IId {
     public DateTimeOffset CreatedAt { get; private set; }
     public DateTimeOffset? UpdatedAt { get; private set; }
     public DateTimeOffset? DeletedAt { get; private set; }
@@ -51,7 +51,7 @@ public abstract class Aggregate<TId> : Entity<TId>, IAggregate, IHasDomainEvent
     }
 }
 
-public abstract class Entity<TId> where TId : class, IId<TId> {
+public abstract class Entity<TId> where TId : class, IId {
     public TId Id { get; private set; }
 
 #pragma warning disable CS8618

--- a/src/Libraries/Auctify.Libraries.Domain.Abstractions/ValueObjects/IId.cs
+++ b/src/Libraries/Auctify.Libraries.Domain.Abstractions/ValueObjects/IId.cs
@@ -1,5 +1,6 @@
 ﻿namespace Auctify.Libraries.Domain.Abstractions.ValueObjects;
-public interface IId<out TSelf, TValue> : IValueObject<TSelf> {
+public interface IId;
+public interface IId<out TSelf, TValue> : IId, IValueObject<TSelf> {
     TValue Value { get; }
     static abstract TSelf From(TValue value);
 }

--- a/src/Services/CatalogService/Auctify.CatalogService.Application/Auctify.CatalogService.Application.csproj
+++ b/src/Services/CatalogService/Auctify.CatalogService.Application/Auctify.CatalogService.Application.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/Services/CatalogService/Auctify.CatalogService.Application/Auctify.CatalogService.Application.csproj
+++ b/src/Services/CatalogService/Auctify.CatalogService.Application/Auctify.CatalogService.Application.csproj
@@ -6,4 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Auctify.CatalogService.Domain\Auctify.CatalogService.Domain.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/Services/CatalogService/Auctify.CatalogService.Application/GetAuctionItemByIdQuery.cs
+++ b/src/Services/CatalogService/Auctify.CatalogService.Application/GetAuctionItemByIdQuery.cs
@@ -1,15 +1,29 @@
-﻿namespace Auctify.CatalogService.Application; 
-public sealed record GetAuctionItemByIdQuery {
+﻿using Auctify.CatalogService.Application.Repositories;
+using Auctify.CatalogService.Domain;
 
-}
+namespace Auctify.CatalogService.Application; 
+public sealed record GetAuctionItemByIdQuery(Guid Id);
 
 public sealed record GetAuctionItemByIdQueryResult {
-
+    public Guid Id { get; internal set; }
+    public   string Name { get; internal set; }
+    public DateTimeOffset CreatedAt { get; internal set; }
 }
 
 public sealed class GetAuctionItemByIdQueryHandler {
-    public ValueTask<GetAuctionItemByIdQueryResult> HandleAsync(GetAuctionItemByIdQuery query, CancellationToken cancellationToken) {
+    private readonly IAuctionItemRepository _repository;
 
-        return ValueTask.FromResult(new GetAuctionItemByIdQueryResult());
+    public GetAuctionItemByIdQueryHandler(IAuctionItemRepository repository) {
+        _repository = repository;
     }
-} 
+
+    public async ValueTask<GetAuctionItemByIdQueryResult> HandleAsync(GetAuctionItemByIdQuery query, CancellationToken cancellationToken) {
+        AuctionItem auctionItem = await _repository.GetByIdAsync(AuctionItemId.From(query.Id));
+         
+        return new GetAuctionItemByIdQueryResult {
+            Id = auctionItem.Id.Value,
+            Name = auctionItem.Name,
+            CreatedAt = auctionItem.CreatedAt
+        };
+    }
+}

--- a/src/Services/CatalogService/Auctify.CatalogService.Application/GetAuctionItemByIdQuery.cs
+++ b/src/Services/CatalogService/Auctify.CatalogService.Application/GetAuctionItemByIdQuery.cs
@@ -1,0 +1,15 @@
+﻿namespace Auctify.CatalogService.Application; 
+public sealed record GetAuctionItemByIdQuery {
+
+}
+
+public sealed record GetAuctionItemByIdQueryResult {
+
+}
+
+public sealed class GetAuctionItemByIdQueryHandler {
+    public ValueTask<GetAuctionItemByIdQueryResult> HandleAsync(GetAuctionItemByIdQuery query, CancellationToken cancellationToken) {
+
+        return ValueTask.FromResult(new GetAuctionItemByIdQueryResult());
+    }
+}

--- a/src/Services/CatalogService/Auctify.CatalogService.Application/GetAuctionItemByIdQuery.cs
+++ b/src/Services/CatalogService/Auctify.CatalogService.Application/GetAuctionItemByIdQuery.cs
@@ -12,4 +12,4 @@ public sealed class GetAuctionItemByIdQueryHandler {
 
         return ValueTask.FromResult(new GetAuctionItemByIdQueryResult());
     }
-}
+} 

--- a/src/Services/CatalogService/Auctify.CatalogService.Application/GetAuctionItemByIdQuery.cs
+++ b/src/Services/CatalogService/Auctify.CatalogService.Application/GetAuctionItemByIdQuery.cs
@@ -8,6 +8,14 @@ public sealed record GetAuctionItemByIdQueryResult {
     public Guid Id { get; internal set; }
     public   string Name { get; internal set; }
     public DateTimeOffset CreatedAt { get; internal set; }
+
+    public static GetAuctionItemByIdQueryResult From(AuctionItem auctionItem) {
+        return new GetAuctionItemByIdQueryResult {
+            Id = auctionItem.Id.Value,
+            Name = auctionItem.Name,
+            CreatedAt = auctionItem.CreatedAt
+        };
+    }
 }
 
 public sealed class GetAuctionItemByIdQueryHandler {
@@ -20,10 +28,6 @@ public sealed class GetAuctionItemByIdQueryHandler {
     public async ValueTask<GetAuctionItemByIdQueryResult> HandleAsync(GetAuctionItemByIdQuery query, CancellationToken cancellationToken) {
         AuctionItem auctionItem = await _repository.GetByIdAsync(AuctionItemId.From(query.Id));
          
-        return new GetAuctionItemByIdQueryResult {
-            Id = auctionItem.Id.Value,
-            Name = auctionItem.Name,
-            CreatedAt = auctionItem.CreatedAt
-        };
+        return GetAuctionItemByIdQueryResult.From(auctionItem);
     }
 }

--- a/src/Services/CatalogService/Auctify.CatalogService.Application/Repositories/IAuctionItemRepository.cs
+++ b/src/Services/CatalogService/Auctify.CatalogService.Application/Repositories/IAuctionItemRepository.cs
@@ -1,0 +1,6 @@
+﻿using Auctify.CatalogService.Domain;
+
+namespace Auctify.CatalogService.Application.Repositories;
+public interface IAuctionItemRepository {
+    Task<AuctionItem> GetByIdAsync(AuctionItemId id);
+}

--- a/src/Services/CatalogService/Auctify.CatalogService.Domain/Auctify.CatalogService.Domain.csproj
+++ b/src/Services/CatalogService/Auctify.CatalogService.Domain/Auctify.CatalogService.Domain.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Libraries\Auctify.Libraries.Domain.Abstractions\Auctify.Libraries.Domain.Abstractions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Services/CatalogService/Auctify.CatalogService.Domain/AuctionItem.cs
+++ b/src/Services/CatalogService/Auctify.CatalogService.Domain/AuctionItem.cs
@@ -1,0 +1,11 @@
+﻿using Auctify.Libraries.Domain.Abstractions;
+
+namespace Auctify.CatalogService.Domain;
+public sealed class AuctionItem : Aggregate<AuctionItemId> {
+    public AuctionItem() {
+    }
+
+#pragma warning disable CS0628 // New protected member declared in sealed type
+    protected AuctionItem(AuctionItemId id) : base(id) { }
+#pragma warning restore CS0628 // New protected member declared in sealed type
+}

--- a/src/Services/CatalogService/Auctify.CatalogService.Domain/AuctionItem.cs
+++ b/src/Services/CatalogService/Auctify.CatalogService.Domain/AuctionItem.cs
@@ -2,10 +2,17 @@
 
 namespace Auctify.CatalogService.Domain;
 public sealed class AuctionItem : Aggregate<AuctionItemId> {
-    public AuctionItem() {
-    }
+    public string Name { get; private set; } = null!;
+    private AuctionItem() { }
 
 #pragma warning disable CS0628 // New protected member declared in sealed type
     protected AuctionItem(AuctionItemId id) : base(id) { }
 #pragma warning restore CS0628 // New protected member declared in sealed type
+
+    public static AuctionItem New(string name) {
+        AuctionItem item = new(AuctionItemId.New());
+        item.SetCreatedAt(DateTimeOffset.UtcNow);
+        item.Name = name;
+        return item;
+    } 
 }

--- a/src/Services/CatalogService/Auctify.CatalogService.Domain/AuctionItemId.cs
+++ b/src/Services/CatalogService/Auctify.CatalogService.Domain/AuctionItemId.cs
@@ -1,0 +1,19 @@
+﻿using Auctify.Libraries.Domain.Abstractions.ValueObjects;
+using Wiaoj;
+
+namespace Auctify.CatalogService.Domain;
+public sealed record AuctionItemId : IId<AuctionItemId, Guid> {
+    public Guid Value { get; }
+    private AuctionItemId(Guid value) {
+        this.Value = value;
+    }
+
+    public static AuctionItemId From(Guid value) {
+        Preca.ThrowIfDefault(value);
+        return new(value);
+    }
+
+    public static AuctionItemId New() {
+        return new(Guid.CreateVersion7());
+    }
+}

--- a/src/Services/CatalogService/Auctify.CatalogService.Infrastructure/Auctify.CatalogService.Infrastructure.csproj
+++ b/src/Services/CatalogService/Auctify.CatalogService.Infrastructure/Auctify.CatalogService.Infrastructure.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/Services/CatalogService/Auctify.CatalogService.Infrastructure/Auctify.CatalogService.Infrastructure.csproj
+++ b/src/Services/CatalogService/Auctify.CatalogService.Infrastructure/Auctify.CatalogService.Infrastructure.csproj
@@ -6,4 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Auctify.CatalogService.Application\Auctify.CatalogService.Application.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/Services/CatalogService/Auctify.CatalogService.Infrastructure/Persistence/Repositories/AuctionItemRepository.cs
+++ b/src/Services/CatalogService/Auctify.CatalogService.Infrastructure/Persistence/Repositories/AuctionItemRepository.cs
@@ -1,0 +1,9 @@
+﻿using Auctify.CatalogService.Application.Repositories;
+using Auctify.CatalogService.Domain;
+
+namespace Auctify.CatalogService.Infrastructure.Persistence.Repositories;
+internal sealed class AuctionItemRepository : IAuctionItemRepository {
+    public Task<AuctionItem> GetByIdAsync(AuctionItemId id) { 
+        return Task.FromResult(AuctionItem.New("Test Müzayedesi"));
+    }
+}

--- a/src/Services/CatalogService/Auctify.CatalogService.Infrastructure/Persistence/Repositories/AuctionItemRepository.cs
+++ b/src/Services/CatalogService/Auctify.CatalogService.Infrastructure/Persistence/Repositories/AuctionItemRepository.cs
@@ -2,7 +2,7 @@
 using Auctify.CatalogService.Domain;
 
 namespace Auctify.CatalogService.Infrastructure.Persistence.Repositories;
-internal sealed class AuctionItemRepository : IAuctionItemRepository {
+public sealed class AuctionItemRepository : IAuctionItemRepository {
     public Task<AuctionItem> GetByIdAsync(AuctionItemId id) { 
         return Task.FromResult(AuctionItem.New("Test Müzayedesi"));
     }

--- a/src/Services/CatalogService/Auctify.CatalogService.WebAPI/Auctify.CatalogService.WebAPI.csproj
+++ b/src/Services/CatalogService/Auctify.CatalogService.WebAPI/Auctify.CatalogService.WebAPI.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/src/Services/CatalogService/Auctify.CatalogService.WebAPI/Auctify.CatalogService.WebAPI.csproj
+++ b/src/Services/CatalogService/Auctify.CatalogService.WebAPI/Auctify.CatalogService.WebAPI.csproj
@@ -6,4 +6,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Auctify.CatalogService.Infrastructure\Auctify.CatalogService.Infrastructure.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/Services/CatalogService/Auctify.CatalogService.WebAPI/Auctify.CatalogService.WebAPI.http
+++ b/src/Services/CatalogService/Auctify.CatalogService.WebAPI/Auctify.CatalogService.WebAPI.http
@@ -1,0 +1,6 @@
+@Auctify.CatalogService.WebAPI_HostAddress = http://localhost:5078
+
+GET {{Auctify.CatalogService.WebAPI_HostAddress}}/weatherforecast/
+Accept: application/json
+
+###

--- a/src/Services/CatalogService/Auctify.CatalogService.WebAPI/Program.cs
+++ b/src/Services/CatalogService/Auctify.CatalogService.WebAPI/Program.cs
@@ -1,6 +1,12 @@
+using Auctify.CatalogService.Application;
+using Auctify.CatalogService.Application.Repositories;
+using Auctify.CatalogService.Infrastructure.Persistence.Repositories;
+
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
-// Add services to the container.
+builder.Services.AddScoped<GetAuctionItemByIdQueryHandler>(); 
+builder.Services.AddScoped<IAuctionItemRepository, AuctionItemRepository>();
+
 
 WebApplication app = builder.Build();
 

--- a/src/Services/CatalogService/Auctify.CatalogService.WebAPI/Program.cs
+++ b/src/Services/CatalogService/Auctify.CatalogService.WebAPI/Program.cs
@@ -14,6 +14,12 @@ WebApplication app = builder.Build();
 
 app.UseHttpsRedirection();
 
+var catalogApi= app.MapGroup("api/catalog");
 
+catalogApi.MapGet("{id:guid}", async (Guid id, GetAuctionItemByIdQueryHandler handler, CancellationToken cancellationToken) => {
+    GetAuctionItemByIdQuery query = new(id);
+    GetAuctionItemByIdQueryResult result = await handler.HandleAsync(query, cancellationToken);
+    return Results.Ok(result);
+});
 
 await app.RunAsync(default(CancellationToken));

--- a/src/Services/CatalogService/Auctify.CatalogService.WebAPI/Program.cs
+++ b/src/Services/CatalogService/Auctify.CatalogService.WebAPI/Program.cs
@@ -1,0 +1,13 @@
+WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+
+WebApplication app = builder.Build();
+
+// Configure the HTTP request pipeline.
+
+app.UseHttpsRedirection();
+
+
+
+await app.RunAsync(default(CancellationToken));

--- a/src/Services/CatalogService/Auctify.CatalogService.WebAPI/Properties/launchSettings.json
+++ b/src/Services/CatalogService/Auctify.CatalogService.WebAPI/Properties/launchSettings.json
@@ -1,0 +1,23 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5078",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "https://localhost:7097;http://localhost:5078",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/Services/CatalogService/Auctify.CatalogService.WebAPI/appsettings.Development.json
+++ b/src/Services/CatalogService/Auctify.CatalogService.WebAPI/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/Services/CatalogService/Auctify.CatalogService.WebAPI/appsettings.json
+++ b/src/Services/CatalogService/Auctify.CatalogService.WebAPI/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
Closes #7

### Summary

This pull request introduces the foundational implementation of the `CatalogService`, which will be responsible for managing the lifecycle of auction items.

This service is built following strict **Clean Architecture** and **Domain-Driven Design (DDD)** principles, establishing a robust and scalable blueprint for all future CRUD-based services in the Auctify platform. It serves as the reference implementation for our architectural vision.

### Key Changes Implemented

- **Clean Architecture Structure:** Created the four core projects: `Domain`, `Application`, `Infrastructure`, and `WebAPI`.
- **Shared Kernel Integration:** Leveraged the new `Auctify.Libraries.Domain.Abstractions` project for base classes like `Aggregate<TId>` and `IId<TSelf>`.
- **DDD Implementation:**
    -   Implemented the `AuctionItem` as an Aggregate Root in the `Domain` layer.
    -   Created a strongly-typed `AuctionItemId` Value Object to prevent primitive obsession.
- **CQRS Flow:** Built a simple, end-to-end "read" pipeline:
    -   `GetAuctionItemByIdQuery` and `GetAuctionItemByIdQueryHandler` in the `Application` layer.
    -   `IAuctionItemRepository` interface in `Application` and its in-memory implementation in `Infrastructure`.
- **API Endpoint:** Exposed the functionality through a `GET /{id}` endpoint in the `CatalogController`.
- **Dependency Injection:** Configured DI in the `WebAPI` layer to correctly resolve and inject services from all layers.

### How to Test

1.  Run the `Auctify.CatalogService.WebAPI` project.
2.  Open a browser or API client (like Postman).
3.  Make a `GET` request to the following URL, replacing `{GUID}` with any valid GUID:
    `https://localhost:PORT/api/catalog/{GUID}`
4.  **Expected Result:** The API should return a `200 OK` status with a JSON object representing the hardcoded "Test Müzayedesi" item, proving that all architectural layers are correctly wired up.