### PR TITLE
feat(domain): Implement Money, Currency, and Amount Value Objects

### DIFF
--- a/Auctify.sln
+++ b/Auctify.sln
@@ -31,6 +31,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Auctify.BiddingService.WebA
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Auctify.Libraries.Shared.Contracts", "src\Libraries\Auctify.Libraries.Shared.Contracts\Auctify.Libraries.Shared.Contracts.csproj", "{ACBDC496-EC72-463C-A751-E96CCD755E97}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Auctify.Libraries.Domain", "src\Libraries\Auctify.Libraries.Domain\Auctify.Libraries.Domain.csproj", "{AA7017F6-E6BE-4AFF-9C1C-A83DC3A39BED}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -137,6 +139,18 @@ Global
 		{ACBDC496-EC72-463C-A751-E96CCD755E97}.Release|x64.Build.0 = Release|Any CPU
 		{ACBDC496-EC72-463C-A751-E96CCD755E97}.Release|x86.ActiveCfg = Release|Any CPU
 		{ACBDC496-EC72-463C-A751-E96CCD755E97}.Release|x86.Build.0 = Release|Any CPU
+		{AA7017F6-E6BE-4AFF-9C1C-A83DC3A39BED}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AA7017F6-E6BE-4AFF-9C1C-A83DC3A39BED}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AA7017F6-E6BE-4AFF-9C1C-A83DC3A39BED}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{AA7017F6-E6BE-4AFF-9C1C-A83DC3A39BED}.Debug|x64.Build.0 = Debug|Any CPU
+		{AA7017F6-E6BE-4AFF-9C1C-A83DC3A39BED}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{AA7017F6-E6BE-4AFF-9C1C-A83DC3A39BED}.Debug|x86.Build.0 = Debug|Any CPU
+		{AA7017F6-E6BE-4AFF-9C1C-A83DC3A39BED}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AA7017F6-E6BE-4AFF-9C1C-A83DC3A39BED}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AA7017F6-E6BE-4AFF-9C1C-A83DC3A39BED}.Release|x64.ActiveCfg = Release|Any CPU
+		{AA7017F6-E6BE-4AFF-9C1C-A83DC3A39BED}.Release|x64.Build.0 = Release|Any CPU
+		{AA7017F6-E6BE-4AFF-9C1C-A83DC3A39BED}.Release|x86.ActiveCfg = Release|Any CPU
+		{AA7017F6-E6BE-4AFF-9C1C-A83DC3A39BED}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -155,6 +169,7 @@ Global
 		{02EA681E-C7D8-13C7-8484-4AC65E1B71E8} = {984BB9B3-3FA3-BE33-9484-CAC21695A33C}
 		{2DB34A1D-AA95-4E72-B078-8990838DF930} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{ACBDC496-EC72-463C-A751-E96CCD755E97} = {5E7EC0AF-E837-5B7A-FB41-A4DCCA877D1F}
+		{AA7017F6-E6BE-4AFF-9C1C-A83DC3A39BED} = {5E7EC0AF-E837-5B7A-FB41-A4DCCA877D1F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7B78C610-CFBA-4D61-A80C-D796B32E65C4}

--- a/src/Libraries/Auctify.Libraries.Domain.Abstractions/ValueObjects/IId.cs
+++ b/src/Libraries/Auctify.Libraries.Domain.Abstractions/ValueObjects/IId.cs
@@ -14,3 +14,6 @@ public interface IValueObject<out TSelf> {
 public interface IValueObject<out TSelf, in TValue> {
     static abstract TSelf New(TValue value);
 }
+public interface IValueObject<out TSelf, in TValue1, in TValue2> {
+    static abstract TSelf New(TValue1 value1, TValue2 value2);
+}

--- a/src/Libraries/Auctify.Libraries.Domain/Auctify.Libraries.Domain.csproj
+++ b/src/Libraries/Auctify.Libraries.Domain/Auctify.Libraries.Domain.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Auctify.Libraries.Domain.Abstractions\Auctify.Libraries.Domain.Abstractions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Libraries/Auctify.Libraries.Domain/Extensions/PrecaExtensions.cs
+++ b/src/Libraries/Auctify.Libraries.Domain/Extensions/PrecaExtensions.cs
@@ -1,0 +1,13 @@
+﻿using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using Wiaoj;
+
+namespace Auctify.Libraries.Domain.Extensions;
+internal static class PrecaExtensions {
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [DebuggerNonUserCode, DebuggerHidden, DebuggerStepThrough]
+    public static void ThrowIfLeftOrRightNull<T>(this Wiaoj.PrecaExtensions _, T left, T right) {
+        Preca.ThrowIfNull(left);
+        Preca.ThrowIfNull(right);
+    }
+}

--- a/src/Libraries/Auctify.Libraries.Domain/ValueObjects/Amount.cs
+++ b/src/Libraries/Auctify.Libraries.Domain/ValueObjects/Amount.cs
@@ -1,0 +1,65 @@
+﻿using System.Numerics;
+using Auctify.Libraries.Domain.Abstractions.ValueObjects;
+using Auctify.Libraries.Domain.Extensions;
+using Wiaoj;
+
+namespace Auctify.Libraries.Domain.ValueObjects;
+public sealed record Amount : IValueObject<Amount, decimal>,
+    IAdditionOperators<Amount, Amount, Amount>,
+    ISubtractionOperators<Amount, Amount, Amount>,
+    IMultiplyOperators<Amount, Amount, Amount>,
+    IDivisionOperators<Amount, Amount, Amount>,
+    IComparisonOperators<Amount, Amount, bool>,
+    IEqualityOperators<Amount, Amount, bool> {
+    public decimal Value { get; init; }
+
+    private Amount() { }
+    private Amount(decimal value) { 
+        Value = value;
+    }
+
+    public static Amount New(decimal value) {
+        Preca.ThrowIfNegative(value); 
+        return new(Math.Round(value, 2));
+    }
+
+    public static Amount operator +(Amount left, Amount right) {
+        Preca.Extensions.ThrowIfLeftOrRightNull(left, right);
+        return New(left.Value + right.Value);
+    }
+
+    public static Amount operator *(Amount left, Amount right) {
+        Preca.Extensions.ThrowIfLeftOrRightNull(left, right);
+        return New(left.Value * right.Value);
+    }
+
+    public static Amount operator -(Amount left, Amount right) {
+        Preca.Extensions.ThrowIfLeftOrRightNull(left, right);
+        return New(left.Value - right.Value);
+    }
+
+    public static Amount operator /(Amount left, Amount right) {
+        Preca.Extensions.ThrowIfLeftOrRightNull(left, right);
+        return New(left.Value / right.Value);
+    }
+
+    public static bool operator >(Amount left, Amount right) {
+        Preca.Extensions.ThrowIfLeftOrRightNull(left, right);
+        return left.Value > right.Value;
+    }
+
+    public static bool operator >=(Amount left, Amount right) {
+        Preca.Extensions.ThrowIfLeftOrRightNull(left, right);
+        return left.Value >= right.Value;
+    }
+
+    public static bool operator <(Amount left, Amount right) {
+        Preca.Extensions.ThrowIfLeftOrRightNull(left, right);
+        return left.Value < right.Value;
+    }
+
+    public static bool operator <=(Amount left, Amount right) {
+        Preca.Extensions.ThrowIfLeftOrRightNull(left, right);
+        return left.Value <= right.Value;
+    }
+} 

--- a/src/Libraries/Auctify.Libraries.Domain/ValueObjects/Currency.cs
+++ b/src/Libraries/Auctify.Libraries.Domain/ValueObjects/Currency.cs
@@ -1,0 +1,36 @@
+﻿using System.Text.RegularExpressions;
+using Auctify.Libraries.Domain.Abstractions.ValueObjects;
+using Wiaoj;
+
+namespace Auctify.Libraries.Domain.ValueObjects;
+// Represents a currency code, typically a 3-letter ISO 4217 code.
+// https://en.wikipedia.org/wiki/ISO_4217
+public sealed partial record Currency : IValueObject<Currency, string> {
+    public static readonly Currency USD = new("USD");
+    public static readonly Currency EUR = new("EUR");
+    public static readonly Currency TRY = new("TRY");
+    public string Value { get; private set; }
+
+    private Currency(string value) {
+        this.Value = value;
+    }
+
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
+    private Currency() { }
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
+
+    public static Currency New(string value) {
+        Preca.ThrowIfNullOrWhiteSpace(value);
+        string upperCode = value.ToUpperInvariant();
+
+        Preca.ThrowIfFalse(
+            ISO4217Regex().IsMatch(upperCode),
+            static () => new ArgumentException("Currency code must be 3 alphabetic characters."));
+
+        // Doğrudan private constructor'ı çağırıyoruz.
+        return new Currency(upperCode);
+    }
+
+    [GeneratedRegex("^[A-Z]{3}$")]
+    private static partial Regex ISO4217Regex();
+}

--- a/src/Libraries/Auctify.Libraries.Domain/ValueObjects/Money.cs
+++ b/src/Libraries/Auctify.Libraries.Domain/ValueObjects/Money.cs
@@ -1,0 +1,47 @@
+﻿using System.Numerics;
+using Auctify.Libraries.Domain.Abstractions.ValueObjects;
+using Auctify.Libraries.Domain.Extensions;
+using Wiaoj;
+using Wiaoj.Extensions;
+
+namespace Auctify.Libraries.Domain.ValueObjects;
+public sealed record Money : IValueObject<Money, Amount, Currency>, 
+    IAdditionOperators<Money, Money, Money>,
+    ISubtractionOperators<Money, Money, Money> {
+    public Amount Amount { get; }
+    public Currency Currency { get; }
+     
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
+    private Money() { }
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
+
+    private Money(Amount amount, Currency currency) {
+        // Amount ve Currency'nin null olamayacağını garanti altına alıyoruz.
+        this.Amount = Preca.Extensions.ThrowIfNull(amount);
+        this.Currency = Preca.Extensions.ThrowIfNull(currency);
+    }
+
+   
+    public static Money New(Amount amount, Currency currency) {
+        Preca.ThrowIfNull(amount);
+        Preca.ThrowIfNull(currency);
+        return new Money(amount, currency);
+    }
+
+    public static Money operator +(Money left, Money right) { 
+        Preca.Extensions.ThrowIfLeftOrRightNull(left, right);
+        Preca.ThrowIf(left.Currency != right.Currency);
+
+        return new Money(left.Amount + right.Amount, left.Currency);
+    }
+
+    public static Money operator -(Money left, Money right) {
+        Preca.Extensions.ThrowIfLeftOrRightNull(left, right);
+        Preca.ThrowIf(left.Currency != right.Currency); 
+        return new Money(left.Amount - right.Amount, left.Currency);
+    }
+
+    public override string ToString() {
+        return $"{this.Amount.Value:F2} {this.Currency.Value}";
+    }
+}


### PR DESCRIPTION
### Summary
This PR completes the first task of the multi-currency epic by introducing the core Value Objects required for handling money within our domain. It replaces the use of primitive types like `decimal` and `string` with rich, self-validating `record` types.

### Key Implementations
 - **`Currency.cs`**: Represents an ISO 4217 currency code with validation and pre-defined common currencies.
 - **`Amount.cs`**: Represents a non-negative monetary value, implementing `INumber` interfaces for safe arithmetic and comparison operations.
 - **`Money.cs`**: Encapsulates `Amount` and `Currency`, preventing cross-currency arithmetic errors.
- **ORM Compatibility**: All Value Objects include a `private` parameterless constructor to ensure compatibility with Entity Framework Core.

---
Closes #14