### PR TITLE
feat(wallet): Implement CreateWalletCommand and handler

### DIFF
--- a/src/Libraries/Auctify.Libraries.Domain.Abstractions/Aggregate.cs
+++ b/src/Libraries/Auctify.Libraries.Domain.Abstractions/Aggregate.cs
@@ -5,7 +5,7 @@ using Wiaoj;
 using Wiaoj.Extensions;
 
 namespace Auctify.Libraries.Domain.Abstractions;
-public abstract class Aggregate<TId> : Entity<TId>, IAggregate, IHasDomainEvent
+public abstract class Aggregate<TId> : Entity<TId>, IAggregate
     where TId : class, IId {
     public DateTimeOffset CreatedAt { get; private set; }
     public DateTimeOffset? UpdatedAt { get; private set; }

--- a/src/Libraries/Auctify.Libraries.Domain.Abstractions/IUpdatable.cs
+++ b/src/Libraries/Auctify.Libraries.Domain.Abstractions/IUpdatable.cs
@@ -1,4 +1,6 @@
-﻿namespace Auctify.Libraries.Domain.Abstractions;
+﻿using Auctify.Libraries.Domain.Abstractions.DomainEvents;
+
+namespace Auctify.Libraries.Domain.Abstractions;
 public interface IUpdatable {
     DateTimeOffset? UpdatedAt { get; }
     void SetUpdatedAt(DateTimeOffset updatedAt);
@@ -13,4 +15,4 @@ public interface ICreatable {
     DateTimeOffset CreatedAt { get; }
     void SetCreatedAt(DateTimeOffset createdAt);
 }
-public interface IAggregate : ICreatable, IUpdatable, IDeletable;
+public interface IAggregate : ICreatable, IUpdatable, IDeletable, IHasDomainEvent;

--- a/src/Services/WalletService/Auctify.WalletService.Application/Abstractions/Persistence/IUnitOfWork.cs
+++ b/src/Services/WalletService/Auctify.WalletService.Application/Abstractions/Persistence/IUnitOfWork.cs
@@ -1,0 +1,4 @@
+﻿namespace Auctify.WalletService.Application.Abstractions.Persistence;
+public interface IUnitOfWork {
+    Task<int> SaveChangesAsync(CancellationToken cancellationToken);
+}

--- a/src/Services/WalletService/Auctify.WalletService.Application/Abstractions/Persistence/IWalletRepository.cs
+++ b/src/Services/WalletService/Auctify.WalletService.Application/Abstractions/Persistence/IWalletRepository.cs
@@ -1,0 +1,6 @@
+﻿using Auctify.WalletService.Domain.Aggregates.WalletAggregate;
+
+namespace Auctify.WalletService.Application.Abstractions.Persistence;
+public interface IWalletRepository {
+    Task AddAsync(Wallet wallet, CancellationToken cancellationToken);
+}

--- a/src/Services/WalletService/Auctify.WalletService.Application/Auctify.WalletService.Application.csproj
+++ b/src/Services/WalletService/Auctify.WalletService.Application/Auctify.WalletService.Application.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Libraries\Auctify.Libraries.Mediator\Auctify.Libraries.Mediator.csproj" />
+    <ProjectReference Include="..\Auctify.WalletService.Domain\Auctify.WalletService.Domain.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Features\Wallets\DomainEvents\" />
+  </ItemGroup>
+
+</Project>

--- a/src/Services/WalletService/Auctify.WalletService.Application/DependencyInjection.cs
+++ b/src/Services/WalletService/Auctify.WalletService.Application/DependencyInjection.cs
@@ -1,0 +1,15 @@
+﻿using System.Reflection;
+using Auctify.Libraries.Mediator;
+using Microsoft.Extensions.DependencyInjection;
+using Wiaoj;
+
+namespace Auctify.WalletService.Application;
+public static class DependencyInjection {
+    public static IServiceCollection AddWalletApplicationServices(this IServiceCollection services) {
+        Preca.ThrowIfNull(services);
+        services.AddAuctifyMediator(x => {
+            x.RegisterHandlersFromAssemblies(Assembly.GetExecutingAssembly());
+        });
+        return services;
+    }
+}

--- a/src/Services/WalletService/Auctify.WalletService.Application/Features/Wallets/Commands/CreateWallet/CreateWalletCommand.cs
+++ b/src/Services/WalletService/Auctify.WalletService.Application/Features/Wallets/Commands/CreateWallet/CreateWalletCommand.cs
@@ -1,0 +1,8 @@
+﻿namespace Auctify.WalletService.Application.Features.Wallets.Commands.CreateWallet;
+public sealed record CreateWalletCommand : IRequest<CreateWalletResult> {
+    public required Guid UserId { get; init; }
+    public required Amount InitialAmount { get; init; }
+    public required Currency Currency { get; init; }
+}
+
+public sealed record CreateWalletResult(Guid WalletId);

--- a/src/Services/WalletService/Auctify.WalletService.Application/Features/Wallets/Commands/CreateWallet/CreateWalletCommandHandler.cs
+++ b/src/Services/WalletService/Auctify.WalletService.Application/Features/Wallets/Commands/CreateWallet/CreateWalletCommandHandler.cs
@@ -1,0 +1,23 @@
+﻿using Auctify.WalletService.Domain.Aggregates.WalletAggregate;
+using Auctify.WalletService.Domain.Aggregates.WalletAggregate.ValueObjects;
+
+namespace Auctify.WalletService.Application.Features.Wallets.Commands.CreateWallet;
+internal sealed class CreateWalletCommandHandler(IWalletRepository walletRepository, IUnitOfWork unitOfWork, TimeProvider timeProvider)
+    : IRequestHandler<CreateWalletCommand, CreateWalletResult> {
+    public async Task<CreateWalletResult> HandleAsync(IRequestContext<CreateWalletCommand> context, CancellationToken cancellationToken) {
+        CreateWalletCommand command = context.Request;
+
+        Wallet wallet = Wallet.New(
+            WalletId.New(),
+            command.UserId,
+            Money.New(command.InitialAmount, command.Currency),
+            timeProvider
+        );
+         
+        await walletRepository.AddAsync(wallet, cancellationToken);
+        await context.PublishAsync(wallet.DomainEvents);
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+
+        return new CreateWalletResult(wallet.Id.Value);
+    }
+}

--- a/src/Services/WalletService/Auctify.WalletService.Application/GlobalUsings.cs
+++ b/src/Services/WalletService/Auctify.WalletService.Application/GlobalUsings.cs
@@ -1,0 +1,3 @@
+﻿global using global::Auctify.Libraries.Domain.ValueObjects;
+global using global::Auctify.Libraries.Mediator.Abstractions;
+global using global::Auctify.WalletService.Application.Abstractions.Persistence;

--- a/src/Services/WalletService/Auctify.WalletService.WebAPI/Auctify.WalletService.WebAPI.csproj
+++ b/src/Services/WalletService/Auctify.WalletService.WebAPI/Auctify.WalletService.WebAPI.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Auctify.WalletService.Application\Auctify.WalletService.Application.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Services/WalletService/Auctify.WalletService.WebAPI/Auctify.WalletService.WebAPI.http
+++ b/src/Services/WalletService/Auctify.WalletService.WebAPI/Auctify.WalletService.WebAPI.http
@@ -1,0 +1,6 @@
+@Auctify.WalletService.WebAPI_HostAddress = http://localhost:5293
+
+GET {{Auctify.WalletService.WebAPI_HostAddress}}/weatherforecast/
+Accept: application/json
+
+###

--- a/src/Services/WalletService/Auctify.WalletService.WebAPI/Program.cs
+++ b/src/Services/WalletService/Auctify.WalletService.WebAPI/Program.cs
@@ -1,0 +1,13 @@
+using Auctify.WalletService.Application;
+
+WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddWalletApplicationServices();
+
+WebApplication app = builder.Build();
+
+// Configure the HTTP request pipeline.
+
+app.UseHttpsRedirection();
+ 
+app.Run(); 

--- a/src/Services/WalletService/Auctify.WalletService.WebAPI/Properties/launchSettings.json
+++ b/src/Services/WalletService/Auctify.WalletService.WebAPI/Properties/launchSettings.json
@@ -1,0 +1,23 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5293",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "https://localhost:7208;http://localhost:5293",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/Services/WalletService/Auctify.WalletService.WebAPI/appsettings.Development.json
+++ b/src/Services/WalletService/Auctify.WalletService.WebAPI/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/Services/WalletService/Auctify.WalletService.WebAPI/appsettings.json
+++ b/src/Services/WalletService/Auctify.WalletService.WebAPI/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
Implements the first 'write' operation for the WalletService using the custom Mediator.

This commit includes the CreateWalletCommand, the corresponding CreateWalletCommandHandler, and the necessary domain and application layer structures. The handler orchestrates the creation of a new Wallet aggregate, publishes the domain events, and persists the changes via IUnitOfWork.

This serves as the foundational implementation for the application's write-side logic.

Closes #32